### PR TITLE
fix: ensure paperless-sftp consume/receipt dir exists via init container

### DIFF
--- a/kubernetes/main/apps/default/paperless/sftp/helmrelease.yaml
+++ b/kubernetes/main/apps/default/paperless/sftp/helmrelease.yaml
@@ -21,6 +21,19 @@ spec:
       sftp:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # Ensure consume subdirs used for tag mapping exist
+          init-consume:
+            image:
+              repository: busybox
+              tag: latest
+            command:
+              - sh
+              - -c
+              - mkdir -p /home/paperless-sftp/consume/receipt
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
         containers:
           server:
             image:
@@ -99,6 +112,8 @@ spec:
         existingClaim: paperless-consume
         advancedMounts:
           sftp:
+            init-consume:
+              - path: /home/paperless-sftp/consume
             server:
               - path: /home/paperless-sftp/consume
                 readOnly: false


### PR DESCRIPTION
## Summary
- The Brother scanner's scan-to-SFTP job uploads to `consume/receipt/`, but that subdirectory didn't exist on the `paperless-consume` PVC, so those uploads failed while plain `consume/` uploads worked.
- Adds an `init-consume` init container (busybox, `runAsUser/Group: 1000`) to the `paperless-sftp` HelmRelease that runs `mkdir -p /home/paperless-sftp/consume/receipt` on every pod start, so the directory is recreated automatically if the PVC is ever restored/recreated — same pattern as the mealie VolSync empty-snapshot fix.
- `receipt/` is a tag-mapped subdir (`PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS=true`, `PAPERLESS_CONSUMER_RECURSIVE=true` on the `paperless` app), so files landing there get auto-tagged `receipt`.
- Directory was also created by hand on the live PVC (owned `paperless-sftp:1000`) so scans work immediately without waiting for this to merge/reconcile.

## Test plan
- [ ] Flux reconciles `paperless-sftp` Kustomization and the init container runs successfully
- [ ] Confirm `consume/receipt/` still exists and is owned by `paperless-sftp:1000` after pod restart
- [ ] Re-run a scan to `consume/receipt/` from the scanner and confirm it's consumed and tagged `receipt` in Paperless