### PR TITLE
docs: add AGENTS.md, rewrite README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository. [README.md](./README.md) describes what the cluster is; this file describes how to change it.
+
+This is a GitOps repository for a home Kubernetes cluster. Flux applies whatever is committed here, so the way to change the cluster is to change these files.
+
+## Ground rules
+
+1. **Read-only against the live cluster.** Inspect freely with `kubectl get`, `describe`, `logs`, `flux get`, `k9s`, and `stern`. Anything that changes cluster state (`apply`, `delete`, `patch`, `scale`, `rollout restart`, `flux reconcile`, `flux suspend`, `talosctl`) needs the operator's explicit approval first. Propose the command and say what it will do.
+2. **Never `kubectl apply` over Flux.** Everything under `kubernetes/` is reconciled from git. A hand-applied manifest either gets reverted on the next reconcile or survives as drift that no file explains. Change the file, commit it, and let Flux converge.
+3. **Never write plaintext secrets.** Files matching `*.sops.yaml` are encrypted with age. Editing one in place commits secrets to a public repository. The operator is responsible for keeping secrets up to date.
+4. **Read the plan before implementing.** `plans/` holds design docs written ahead of the work. If a plan covers the task, follow it. If it is stale, say so instead of improvising around it.
+
+## Two cluster trees
+
+| Path | Cluster | Rule |
+|---|---|---|
+| `kubernetes/apollo/` | Talos, the cluster going forward | where new work goes |
+| `kubernetes/main/` | k3s, serving everything today | frozen; disable-only |
+
+`kubernetes/apollo/` does not exist yet. Until it does, changes to running apps still land in `kubernetes/main/`, and each one is worth weighing against the migration: work that Wave 1 will throw away is usually not worth doing.
+
+## How an app is laid out
+
+Each app is a directory under `kubernetes/<cluster>/apps/<namespace>/<app>/`:
+
+```
+mealie/
+  ks.yaml                        Flux Kustomization: dependsOn, targetNamespace, postBuild vars
+  ks-backup.yaml                 second Kustomization for the backup config
+  app/
+    kustomization.yaml
+    helmrelease.yaml             bjw-s app-template, pinned chart version
+    cluster.yaml                 CNPG Cluster, one per app
+    pvc.yaml
+    secret.sops.yaml
+  backup/
+    data-volsync-r2.yaml         VolSync ReplicationSource
+    data-volsync-r2.sops.yaml    restic repository credentials
+```
+
+To add an app:
+
+1. Create the directory following the shape above.
+2. Register its `ks.yaml` in the namespace's `kustomization.yaml`. Flux cannot see an unregistered app.
+3. List every dependency in `dependsOn`. Storage, database, and identity (`longhorn`, `cloudnative-pg`, `authentik`) all belong there, or the first reconcile races.
+4. Pass `APP: *app` through `postBuild.substitute` if the app uses the shared VolSync template.
+5. Validate with `task kubernetes:kubeconform` before opening a PR.
+
+Conventions worth matching: a `# yaml-language-server: $schema=` comment at the top of each manifest, YAML anchors (`name: &app mealie`) instead of repeating the app name, pinned chart and image versions for Renovate to bump, and `${SECRET_DOMAIN}` or `${TIMEZONE}` from `kubernetes/*/flux/vars/` rather than literals.
+
+### Community resources
+
+There is a huge community of home Kubernetes users, many of whom have public repos with their config. This repo heavily relies on these community resources.
+
+An automated way for agents to discover these resources is coming soon. For now, ask the operator to help you find relevant repos/resources, especially when implementing new apps.
+
+Two of them are load-bearing here:
+
+- [home-operations/k8s-schemas](https://github.com/home-operations/k8s-schemas) builds the JSON schemas that the `$schema=` comments and `task kubernetes:kubeconform` validate against. It serves them at `k8s-schemas.home-operations.com`; this repo still points at the older `kubernetes-schemas.pages.dev`. Check there first when a CRD has no schema or fails validation.
+- [home-operations/containers](https://github.com/home-operations/containers) builds rootless application containers. For a workload with no app-specific Helm chart, prefer one of these images, then an upstream image, and only fall back to a custom build when neither does what the app needs.
+
+## Secrets
+
+- Avoid reading secrets from anywhere. Instead, ask the operator to check them for you.
+- Do not leak secrets or potentially sensitive information in any externally visible output (e.g. commits, docs, PR descriptions, etc.).
+- App and cluster secrets live in `*.sops.yaml` and 1Password (synced with ESO).
+  - SOPS: You should never decrypt or edit these files directly. Instead, ask the operator to make the changes for you. For new secrets files, create a file with placeholder values and encrypt with `task sops:encrypt`. Note that only `data` and `stringData` are encrypted, so the rest of the file stays reviewable in a diff.
+  - 1Password: You should never read or write secrets from/to 1Password directly. For new secrets, you can suggest naming/paths and the user will create the entry for you.
+
+## Validating changes
+
+```sh
+task kubernetes:kubeconform     # schema validation, same as CI
+```
+
+CI runs `kubeconform.yaml` and `flux-diff.yaml` on every PR. The flux-diff output shows the rendered manifest delta, which is useful to review when reviewing a Flux change.
+
+## Code style
+
+### Code Comments
+
+I prefer to avoid code comments unless absolutely necessary.
+
+Every comment is a claim the compiler never checks. It can be wrong when written, or go stale as the code drifts. A misleading comment leaves the reader worse off than no comment at all.
+
+- Let the code speak for itself. Prefer a verbose name over an explanatory comment. If a block needs a comment to be readable, try to refactor it instead.
+- No comments about rejected approaches or removed code.
+- Do not document context that belongs in a PR. Comments are not the right place to answer a code review comment.
+- You can document third-party limitations where necessary. Non-obvious behavior in a an app/package we don't control is sometimes worth a comment. Link the upstream bug report so we know when the workaround can go.
+- If you're not 100% sure about a comment, ask me.
+
+If you must add a comment:
+- Keep it extremely short. A long comment costs the reader the time it was meant to save.
+- Wrap at 120 characters. Biome formats code, not comments.
+
+Caveats:
+- some comments have leaked into the codebase. Just because a comment currently exists doesn't mean it's accurate or an acceptable pattern to follow.
+- machine-read annotations and directives are outside this policy.
+
+## Commits and pull requests
+
+Graphite is used to manage the branch/commit/PR lifecycle. The operator's Graphite skills document the current best practices.
+
+## Gotchas
+
+Add new ones here as they are discovered. Remove existing ones when they have been solved.
+
+### VolSync fails on an empty PVC
+
+A restic `ReplicationSource` over a directory with no files errors out instead of taking an empty snapshot. Give the workload an init container that touches a placeholder file. Both `mealie` and `paperless-sftp` do this.
+
+### Stopping a stuck CNPG pod takes two steps
+
+Hibernation alone will not stop it. Suspend the Flux Kustomization, then scale the CNPG operator to zero, or the operator recreates the pod as fast as you remove it. Reverse the order to restore.
+
+### Longhorn ignores disk speed when placing replicas
+
+Keep slow disks out of the pool rather than trusting the scheduler to avoid them.
+
+## Tooling
+
+Local tools are installed/managed with Mise. Everything should be pinned in [`mise.toml`](./mise.toml). Use mise CLI to install/update tools.
+
+Prefer `task <group>:<name>` over raw commands for frequently used tasks; `task` on its own lists what exists.
+
+Talos machine configuration is managed with `topf`, wrapped by `.taskfiles/Talos/`.
+
+## Keeping these docs current
+
+Part of your job is keeping this doc and the README up to date.
+
+Propose an edit when you:
+
+- Learn a convention these docs do not state, or find one they state wrongly.
+- Add or remove something the README describes: a node, an app, a platform component, a task worth knowing about.
+- Hit a failure worth a new entry under Gotchas, or fix one that is already listed. Solved gotchas get removed rather than left behind as history.
+
+Put the doc change in the same PR as the work it describes. A follow-up PR for it rarely gets written.
+
+Two caveats.
+- Be selective about what deserves to be documented. If these docs get too detailed, they will become a maintenance burden.
+- Propose rather than assume. If you are unsure whether something is a real rule or just how one app happens to be written, ask the operator instead of promoting an accident into policy.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,9 @@ Caveats:
 
 Graphite is used to manage the branch/commit/PR lifecycle. The operator's Graphite skills document the current best practices.
 
+Never force push a branch. If the repo gets into a bad state, propose a fix for the operator (who is a git expert) to run manually.
+`gt sync` is generally safe and can be run frequently. `gt sync --force` and `gt submit --force` are not safe.
+
 ## Gotchas
 
 Add new ones here as they are discovered. Remove existing ones when they have been solved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,7 @@ To add an app:
 4. Pass `APP: *app` through `postBuild.substitute` if the app uses the shared VolSync template.
 5. Validate with `task kubernetes:kubeconform` before opening a PR.
 
-Conventions worth matching: a `# yaml-language-server: $schema=` comment at the top of each manifest, YAML anchors (`name: &app mealie`) instead of repeating the app name, pinned chart and image versions for Renovate to bump, and `${SECRET_DOMAIN}` or `${TIMEZONE}` from `kubernetes/*/flux/vars/` rather than literals.
-
-### Community resources
+## Community resources
 
 There is a huge community of home Kubernetes users, many of whom have public repos with their config. This repo heavily relies on these community resources.
 
@@ -59,6 +57,32 @@ Two of them are load-bearing here:
 
 - [home-operations/k8s-schemas](https://github.com/home-operations/k8s-schemas) builds the JSON schemas that the `$schema=` comments and `task kubernetes:kubeconform` validate against. It serves them at `k8s-schemas.home-operations.com`; this repo still points at the older `kubernetes-schemas.pages.dev`. Check there first when a CRD has no schema or fails validation.
 - [home-operations/containers](https://github.com/home-operations/containers) builds rootless application containers. For a workload with no app-specific Helm chart, prefer one of these images, then an upstream image, and only fall back to a custom build when neither does what the app needs.
+
+## Patterns
+
+Guidelines rather than rules. Follow them where they fit. If one takes jumping through hoops to implement, the extra complexity is probably not worth it, so skip it and say why.
+
+### Manifest conventions
+
+Every manifest opens with a `# yaml-language-server: $schema=` comment, and the schema URL tracks the chart version, so bumping one means bumping the other. Use YAML anchors (`name: &app mealie`) instead of repeating the app name. Pin chart and image versions so Renovate can bump them. Take `${SECRET_DOMAIN}` and `${TIMEZONE}` from `kubernetes/*/flux/vars/` rather than writing literals.
+
+### Config in git, credentials in secrets
+
+Configure an app through the chart's Helm values where it supports them, so the whole configuration sits in the HelmRelease. Fall back to a committed file rendered with `configMapGenerator` only when the app needs one the chart cannot produce, as Home Assistant does with `configs/configuration.yaml`.
+
+Credentials arrive as environment variables from a secret, through `envFrom.secretRef` for a bundle or `secretKeyRef` for a single value like the CNPG connection URI. Keep everything else out of the secret so hostnames, database names, and bucket paths stay readable in a diff. If an app wants a secret inside a config file and gives you no way to interpolate one, do not build the mechanism yourself. ESO arrives soon, and an `ExternalSecret` can template a whole config file with its secrets in place; expect that to become the answer for apps that cannot interpolate their own.
+
+### One Flux Kustomization per lifecycle
+
+Split an app into `ks.yaml` plus a satellite for anything with a different failure mode: `ks-backup.yaml`, `ks-sftp.yaml`, `ks-restore.yaml`, `ks-cluster.yaml`. Point the satellite at its own subdirectory and give it a `dependsOn` back to the app. A backup can then fail, or be suspended for a cutover, without disturbing the workload that serves traffic.
+
+### Non-root with a hardened container context
+
+New workloads run as UID and GID 568, with `runAsNonRoot`, `fsGroup: 568`, and `fsGroupChangePolicy: OnRootMismatch` on the pod, and `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `capabilities.drop: ["ALL"]` on the container. Mealie, Home Assistant, and Node-RED are built this way. Some images will not tolerate it. Loosen the one setting that blocks the app rather than dropping the whole block.
+
+### CPU requests, memory limits
+
+Set CPU and memory requests along with a memory limit, and leave the CPU limit off. Throttling a workload through a short busy period costs more than it saves on a cluster this size.
 
 ## Secrets
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Set CPU and memory requests along with a memory limit, and leave the CPU limit o
 task kubernetes:kubeconform     # schema validation, same as CI
 ```
 
-CI runs `kubeconform.yaml` and `flux-diff.yaml` on every PR that touches `kubernetes/**`. Both are path-gated, so a docs-only PR runs neither. The flux-diff output shows the rendered manifest delta, which is useful to review when reviewing a Flux change.
+CI runs `kubeconform.yaml` and `flux-diff.yaml` on PRs that touch `kubernetes/**`. Kubeconform is filtered by path and does not start otherwise; flux-local always starts but skips its test and diff jobs when nothing under `kubernetes/` changed. The flux-diff output shows the rendered manifest delta, which is useful to review when reviewing a Flux change.
 
 ## Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Guidelines rather than rules. Follow them where they fit. If one takes jumping t
 
 ### Manifest conventions
 
-Every manifest opens with a `# yaml-language-server: $schema=` comment, and the schema URL tracks the chart version, so bumping one means bumping the other. Use YAML anchors (`name: &app mealie`) instead of repeating the app name. Pin chart and image versions so Renovate can bump them. Take `${SECRET_DOMAIN}` and `${TIMEZONE}` from `kubernetes/*/flux/vars/` rather than writing literals.
+New manifests should open with a `# yaml-language-server: $schema=` comment, and the schema URL tracks the chart version, so bumping one means bumping the other. Use YAML anchors (`name: &app mealie`) instead of repeating the app name. Pin chart and image versions so Renovate can bump them. Take `${SECRET_DOMAIN}` and `${TIMEZONE}` from `kubernetes/*/flux/vars/` rather than writing literals.
 
 ### Config in git, credentials in secrets
 
@@ -98,7 +98,7 @@ Set CPU and memory requests along with a memory limit, and leave the CPU limit o
 task kubernetes:kubeconform     # schema validation, same as CI
 ```
 
-CI runs `kubeconform.yaml` and `flux-diff.yaml` on every PR. The flux-diff output shows the rendered manifest delta, which is useful to review when reviewing a Flux change.
+CI runs `kubeconform.yaml` and `flux-diff.yaml` on every PR that touches `kubernetes/**`. Both are path-gated, so a docs-only PR runs neither. The flux-diff output shows the rendered manifest delta, which is useful to review when reviewing a Flux change.
 
 ## Code style
 
@@ -168,4 +168,3 @@ Put the doc change in the same PR as the work it describes. A follow-up PR for i
 Two caveats.
 - Be selective about what deserves to be documented. If these docs get too detailed, they will become a maintenance burden.
 - Propose rather than assume. If you are unsure whether something is a real rule or just how one app happens to be written, ask the operator instead of promoting an accident into policy.
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Home Compute Cluster (hcc)
 
 > [!WARNING]
-> **Migration in progress; this README is under construction.** The cluster is moving from ansible-managed k3s to Talos. The new cluster, Apollo, is designed but not yet built, so the workloads described here still run on the old cluster under `kubernetes/main`. Sections marked as placeholders get filled in as the migration proceeds. Where this README and `[plans/20260816-talos-migration.md](./plans/20260816-talos-migration.md)` disagree, the plan wins.
+> **Migration in progress; this README is under construction.** The cluster is moving from ansible-managed k3s to Talos. The new cluster, Apollo, is designed but not yet built, so the workloads described here still run on the old cluster under `kubernetes/main`. Sections marked as placeholders get filled in as the migration proceeds. Where this README and [plans/20260816-talos-migration.md](./plans/20260816-talos-migration.md) disagree, the plan wins.
 
-Kubernetes cluster(s) running the household's services on bare metal in the basement: home automation, recipes, documents, and car telemetry. Flux reconciles everything from this repository using the guiding priciples of GitOps.
+Kubernetes cluster(s) running the household's services on bare metal in the basement: home automation, recipes, documents, and car telemetry. Flux reconciles everything from this repository using the guiding principles of GitOps.
 
 ## Migration status
 
@@ -15,7 +15,7 @@ Kubernetes cluster(s) running the household's services on bare metal in the base
 | Fate         | deleted in Wave 2              | the cluster         |
 
 
-Apps cut over one at a time from verified backups. `kubernetes/main` stays intact for rollback until the last app has moved. `[plans/20260816-talos-migration.md](./plans/20260816-talos-migration.md)` holds the full design: node topology, storage, networking, and per-app data migration.
+Apps cut over one at a time from verified backups. `kubernetes/main` stays intact for rollback until the last app has moved. [plans/20260816-talos-migration.md](./plans/20260816-talos-migration.md) holds the full design: node topology, storage, networking, and per-app data migration.
 
 ## Hardware
 
@@ -31,7 +31,7 @@ Apps cut over one at a time from verified backups. `kubernetes/main` stays intac
 
 ## Day-2 operations
 
-Tools are pinned in `[mise.toml](./mise.toml)` and environment variables in `[.envrc](./.envrc)`. `mise install` and `direnv allow` set up a workstation.
+Tools are pinned in [mise.toml](./mise.toml) and environment variables in [.envrc](./.envrc). `mise install` and `direnv allow` set up a workstation.
 
 ```sh
 task                              # list every task

--- a/README.md
+++ b/README.md
@@ -1,516 +1,78 @@
-# ⛵ Cluster Template
+# Home Compute Cluster (hcc)
 
-Welcome to my opinionated and extensible template for deploying a single Kubernetes cluster. The goal of this project is to make it easier for people interested in using Kubernetes to deploy a cluster at home on bare-metal or VMs.
+> [!WARNING]
+> **Migration in progress; this README is under construction.** The cluster is moving from ansible-managed k3s to Talos. The new cluster, Apollo, is designed but not yet built, so the workloads described here still run on the old cluster under `kubernetes/main`. Sections marked as placeholders get filled in as the migration proceeds. Where this README and `[plans/20260816-talos-migration.md](./plans/20260816-talos-migration.md)` disagree, the plan wins.
 
-At a high level this project makes use of [makejinja](https://github.com/mirkolenz/makejinja) to read in a [configuration file](./config.sample.yaml) which will render out pre-made templates that you can then use to customize your Kubernetes experience further.
+Kubernetes cluster(s) running the household's services on bare metal in the basement: home automation, recipes, documents, and car telemetry. Flux reconciles everything from this repository using the guiding priciples of GitOps.
 
-## ✨ Features
+## Migration status
 
-The features included will depend on the type of configuration you want to use. There are currently **2 different types** of **configurations** available with this template.
 
-1. **"Flux cluster"** - a Kubernetes distribution of your choosing: [k3s](https://github.com/k3s-io/k3s) or [Talos](https://github.com/siderolabs/talos). Deploys an opinionated implementation of [Flux](https://github.com/fluxcd/flux2) using [GitHub](https://github.com/) as the Git provider and [sops](https://github.com/getsops/sops) to manage secrets.
+|              | `kubernetes/main`              | `kubernetes/apollo` |
+| ------------ | ------------------------------ | ------------------- |
+| Distribution | k3s on Debian, ansible-managed | Talos               |
+| Status       | serving all apps; frozen       | not yet created     |
+| Fate         | deleted in Wave 2              | the cluster         |
 
-    - **Required:** Debian 12 or Talos Linux installed on bare metal (or VMs) and some knowledge of [Containers](https://opencontainers.org/) and [YAML](https://yaml.org/). Some knowledge of [Git](https://git-scm.com/) practices & terminology is also required.
-    - **Components:** [Cilium](https://github.com/cilium/cilium) and [kube-vip](https://github.com/kube-vip/kube-vip) _(k3s)_. [flux](https://github.com/fluxcd/flux2), [cert-manager](https://github.com/cert-manager/cert-manager), [spegel](https://github.com/XenitAB/spegel), [reloader](https://github.com/stakater/Reloader), [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) _(k3s)_, and [openebs](https://github.com/openebs/openebs).
 
-3. **"Flux cluster with Cloudflare"** - An addition to "**Flux cluster**" that provides DNS and SSL with [Cloudflare](https://www.cloudflare.com/). [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/) is also included to provide external access to certain applications deployed in your cluster.
+Apps cut over one at a time from verified backups. `kubernetes/main` stays intact for rollback until the last app has moved. `[plans/20260816-talos-migration.md](./plans/20260816-talos-migration.md)` holds the full design: node topology, storage, networking, and per-app data migration.
 
-    - **Required:** A Cloudflare account with a domain managed in your Cloudflare account.
-    - **Components:** [ingress-nginx](https://github.com/kubernetes/ingress-nginx/), [external-dns](https://github.com/kubernetes-sigs/external-dns) and [cloudflared](https://github.com/cloudflare/cloudflared).
+## Hardware
 
-**Other features include:**
+> Placeholder. Filled in as nodes are provisioned.
 
-- A [Renovate](https://www.mend.io/renovate)-ready repository with pull request diffs provided by [flux-local](https://github.com/allenporter/flux-local)
-- Integrated [GitHub Actions](https://github.com/features/actions) with helpful workflows.
 
-## 💻 Machine Preparation
 
-Hopefully some of this peeked your interests!  If you are marching forward, now is a good time to choose whether you will deploy a Kubernetes cluster with [k3s](https://github.com/k3s-io/k3s) or [Talos](https://github.com/siderolabs/talos).
+## What runs here
 
-### System requirements
+> Placeholder. Filled in as apps are deployed.
 
-> [!NOTE]
-> 1. The included behaviour of Talos or k3s is that all nodes are able to run workloads, **including** the controller nodes. **Worker nodes** are therefore **optional**.
-> 2. Do you have 3 or more nodes? It is highly recommended to make 3 of them controller nodes for a highly available control plane.
-> 3. Running the cluster on Proxmox VE? My thoughts and recommendations about that are documented [here](https://onedr0p.github.io/home-ops/notes/proxmox-considerations.html).
 
-| Role    | Cores    | Memory        | System Disk               |
-|---------|----------|---------------|---------------------------|
-| Control | 4 _(6*)_ | 8GB _(24GB*)_ | 100GB _(500GB*)_ SSD/NVMe |
-| Worker  | 4 _(6*)_ | 8GB _(24GB*)_ | 100GB _(500GB*)_ SSD/NVMe |
-| _\* recommended_ |
 
-### Talos
+## Day-2 operations
 
-1. Download the latest stable release of Talos from their [GitHub releases](https://github.com/siderolabs/talos/releases). You will want to grab either `metal-amd64.iso` or `metal-rpi_generic-arm64.raw.xz` depending on your system.
-
-2. Take note of the OS drive serial numbers you will need them later on.
-
-3. Flash the iso or raw file to a USB drive and boot to Talos on your nodes with it.
-
-4. Continue on to 🚀 [**Getting Started**](#-getting-started)
-
-### k3s (AMD64)
-
-1. Download the latest stable release of Debian from [here](https://cdimage.debian.org/debian-cd/current/amd64/iso-dvd), then follow [this guide](https://www.linuxtechi.com/how-to-install-debian-12-step-by-step) to get it installed. Deviations from the guide:
-
-    ```txt
-    Choose "Guided - use entire disk"
-    Choose "All files in one partition"
-    Delete Swap partition
-    Uncheck all Debian desktop environment options
-    ```
-
-2. [Post install] Remove CD/DVD as apt source
-
-    ```sh
-    su -
-    sed -i '/deb cdrom/d' /etc/apt/sources.list
-    apt update
-    exit
-    ```
-
-3. [Post install] Enable sudo for your non-root user
-
-    ```sh
-    su -
-    apt update
-    apt install -y sudo
-    usermod -aG sudo ${username}
-    echo "${username} ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/${username}
-    exit
-    newgrp sudo
-    sudo apt update
-    ```
-
-4. [Post install] Add SSH keys (or use `ssh-copy-id` on the client that is connecting)
-
-    📍 _First make sure your ssh keys are up-to-date and added to your github account as [instructed](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)._
-
-    ```sh
-    mkdir -m 700 ~/.ssh
-    sudo apt install -y curl
-    curl https://github.com/${github_username}.keys > ~/.ssh/authorized_keys
-    chmod 600 ~/.ssh/authorized_keys
-    ```
-
-### k3s (RasPi4)
-
-<details>
-<summary><i>Click <b>here</b> to read about using a RasPi4</i></summary>
-
-
-> [!NOTE]
-> 1. It is recommended to have an 8GB RasPi model. Most important is to **boot from an external SSD/NVMe** rather than an SD card. This is [supported natively](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html), however if you have an early model you may need to [update the bootloader](https://www.tomshardware.com/how-to/boot-raspberry-pi-4-usb) first.
-> 2. Check the [power requirements](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#power-supply) if using a PoE Hat and a SSD/NVMe dongle.
-
-1. Download the latest stable release of Debian from [here](https://raspi.debian.net/tested-images). _**Do not** use Raspbian or DietPi or any other flavor Linux OS._
-
-2. Flash the image onto an SSD/NVMe drive.
-
-3. Re-mount the drive to your workstation and then do the following (per the [official documentation](https://raspi.debian.net/defaults-and-settings)):
-
-    ```txt
-    Open 'sysconf.txt' in a text editor and save it upon updating the information below
-      - Change 'root_authorized_key' to your desired public SSH key
-      - Change 'root_pw' to your desired root password
-      - Change 'hostname' to your desired hostname
-    ```
-
-4. Connect SSD/NVMe drive to the Raspberry Pi 4 and power it on.
-
-5. [Post install] SSH into the device with the `root` user and then create a normal user account with `adduser ${username}`
-
-6. [Post install] Follow steps 3 and 4 from [k3s (AMD64)](##k3s-amd64).
-
-7. [Post install] Install `python3` which is needed by Ansible.
-
-    ```sh
-    sudo apt install -y python3
-    ```
-
-8. Continue on to 🚀 [**Getting Started**](#-getting-started)
-
-</details>
-
-## 🚀 Getting Started
-
-Once you have installed Talos or Debian on your nodes, there are six stages to getting a Flux-managed cluster up and runnning.
-
-> [!NOTE]
-> For all stages below the commands **MUST** be ran on your personal workstation within your repository directory
-
-### 🎉 Stage 1: Create a Git repository
-
-1. Create a new **public** repository by clicking the big green "Use this template" button at the top of this page.
-
-2. Clone **your new repo** to you local workstation and `cd` into it.
-
-3. Continue on to 🌱 [**Stage 2**](#-stage-2-setup-your-local-workstation-environment)
-
-### 🌱 Stage 2: Setup your local workstation
-
-You have two different options for setting up your local workstation.
-
-- First option is using a `devcontainer` which requires you to have Docker and VSCode installed. This method is the fastest to get going because all the required CLI tools are provided for you in my [devcontainer](https://github.com/onedr0p/cluster-template/pkgs/container/cluster-template%2Fdevcontainer) image.
-- The second option is setting up the CLI tools directly on your workstation.
-
-#### Devcontainer method
-
-1. Start Docker and open your repository in VSCode. There will be a pop-up asking you to use the `devcontainer`, click the button to start using it.
-
-2. Continue on to 🔧 [**Stage 3**](#-stage-3-bootstrap-configuration)
-
-#### Non-devcontainer method
-
-1. Install the most recent version of [task](https://taskfile.dev/), see the [installation docs](https://taskfile.dev/installation/) for other supported platforms.
-
-    ```sh
-    # Homebrew
-    brew install go-task
-    # or, Arch
-    pacman -S --noconfirm go-task && ln -sf /usr/bin/go-task /usr/local/bin/task
-    ```
-
-2. Install the most recent version of [direnv](https://direnv.net/), see the [installation docs](https://direnv.net/docs/installation.html) for other supported platforms.
-
-    ```sh
-    # Homebrew
-    brew install direnv
-    # or, Arch
-    pacman -S --noconfirm direnv
-    ```
-
-    📍 _After `direnv` is installed be sure to **[hook it into your preferred shell](https://direnv.net/docs/hook.html)** and then run `task workstation:direnv`_
-
-3. Install the additional **required** CLI tools
-
-   📍 _**Not using Homebrew or ArchLinux?** Try using the generic Linux task below, if that fails check out the [Brewfile](.taskfiles/Workstation/Brewfile)/[Archfile](.taskfiles/Workstation/Archfile) for what CLI tools needed and install them._
-
-    ```sh
-    # Homebrew
-    task workstation:brew
-    # or, Arch with yay/paru
-    task workstation:arch
-    # or, Generic Linux (YMMV, this pulls binaires in to ./bin)
-    task workstation:generic-linux
-    ```
-
-4. Setup a Python virual environment by running the following task command.
-
-    📍 _This commands requires Python 3.11+ to be installed._
-
-    ```sh
-    task workstation:venv
-    ```
-
-5. Continue on to 🔧 [**Stage 3**](#-stage-3-bootstrap-configuration)
-
-### 🔧 Stage 3: Bootstrap configuration
-
-> [!NOTE]
-> The [config.sample.yaml](./config.sample.yaml) file contains config that is **vital** to the bootstrap process.
-
-1. Generate the `config.yaml` from the [config.sample.yaml](./config.sample.yaml) configuration file.
-
-    ```sh
-    task init
-    ```
-
-2. Fill out the `config.yaml` configuration file using the comments in that file as a guide.
-
-3. Run the following command which will generate all the files needed to continue.
-
-    ```sh
-    task configure
-    ```
-
-4. Push you changes to git
-
-   📍 _**Verify** all the `./kubernetes/**/*.sops.*` files are **encrypted** with SOPS_
-
-    ```sh
-    git add -A
-    git commit -m "Initial commit :rocket:"
-    git push
-    ```
-
-5.  Continue on to ⚡ [**Stage 4**](#-stage-4-prepare-your-nodes-for-kubernetes)
-
-### ⚡ Stage 4: Prepare your nodes for Kubernetes
-
-> [!NOTE]
-> For **Talos** skip ahead to ⛵ [**Stage 5**](#-stage-5-install-kubernetes)
-
-#### k3s
-
-📍 _Here we will be running an Ansible playbook to prepare your nodes for running a Kubernetes cluster._
-
-1. Ensure you are able to SSH into your nodes from your workstation using a private SSH key **without a passphrase** (for example using a SSH agent). This lets Ansible interact with your nodes.
-
-3. Install the Ansible dependencies
-
-    ```sh
-    task ansible:deps
-    ```
-
-4. Verify Ansible can view your config and ping your nodes
-
-    ```sh
-    task ansible:list
-    task ansible:ping
-    ```
-
-5. Run the Ansible prepare playbook (nodes wil reboot when done)
-
-    ```sh
-    task ansible:run playbook=cluster-prepare
-    ```
-
-6. Continue on to ⛵ [**Stage 5**](#-stage-5-install-kubernetes)
-
-### ⛵ Stage 5: Install Kubernetes
-
-#### Talos
-
-1. Deploy your cluster and bootstrap it. This generates secrets, generates the config files for your nodes and applies them. It bootstraps the cluster afterwards, fetches the kubeconfig file and installs Cilium and kubelet-csr-approver. It finishes with some health checks.
-
-    ```sh
-    task talos:bootstrap
-    ```
-
-#### k3s
-
-1. Install Kubernetes depending on the distribution you chose
-
-    ```sh
-    task ansible:run playbook=cluster-installation
-    ```
-
-#### Cluster validation
-
-1. The `kubeconfig` for interacting with your cluster should have been created in the root of your repository.
-
-2. Verify the nodes are online
-
-    📍 _If this command **fails** you likely haven't configured `direnv` as mentioned previously in the guide._
-
-    ```sh
-    kubectl get nodes -o wide
-    # NAME           STATUS   ROLES                       AGE     VERSION
-    # k8s-0          Ready    control-plane,etcd,master   1h      v1.29.1
-    # k8s-1          Ready    worker                      1h      v1.29.1
-    ```
-
-3. Continue on to 🔹 [**Stage 6**](#-stage-6-install-flux-in-your-cluster)
-
-### 🔹 Stage 6: Install Flux in your cluster
-
-1. Verify Flux can be installed
-
-    ```sh
-    flux check --pre
-    # ► checking prerequisites
-    # ✔ kubectl 1.27.3 >=1.18.0-0
-    # ✔ Kubernetes 1.27.3+k3s1 >=1.16.0-0
-    # ✔ prerequisites checks passed
-    ```
-
-2. Install Flux and sync the cluster to the Git repository
-
-    📍 _Run `task flux:github-deploy-key` first if using a private repository._
-
-    ```sh
-    task flux:bootstrap
-    # namespace/flux-system configured
-    # customresourcedefinition.apiextensions.k8s.io/alerts.notification.toolkit.fluxcd.io created
-    # ...
-    ```
-
-1. Verify Flux components are running in the cluster
-
-    ```sh
-    kubectl -n flux-system get pods -o wide
-    # NAME                                       READY   STATUS    RESTARTS   AGE
-    # helm-controller-5bbd94c75-89sb4            1/1     Running   0          1h
-    # kustomize-controller-7b67b6b77d-nqc67      1/1     Running   0          1h
-    # notification-controller-7c46575844-k4bvr   1/1     Running   0          1h
-    # source-controller-7d6875bcb4-zqw9f         1/1     Running   0          1h
-    ```
-
-### 🎤 Verification Steps
-
-_Mic check, 1, 2_ - In a few moments applications should be lighting up like Christmas in July 🎄
-
-1. Output all the common resources in your cluster.
-
-    📍 _Feel free to use the provided [kubernetes tasks](.taskfiles/Kubernetes/Taskfile.yaml) for validation of cluster resources or continue to get familiar with the `kubectl` and `flux` CLI tools._
-
-    ```sh
-    task kubernetes:resources
-    ```
-
-2. ⚠️ It might take `cert-manager` awhile to generate certificates, this is normal so be patient.
-
-3. 🏆 **Congratulations** if all goes smooth you will have a Kubernetes cluster managed by Flux and your Git repository is driving the state of your cluster.
-
-4. 🧠 Now it's time to pause and go get some motel motor oil ☕ and admire you made it this far!
-
-## 📣 Flux w/ Cloudflare post installation
-
-#### 🌐 Public DNS
-
-The `external-dns` application created in the `networking` namespace will handle creating public DNS records. By default, `echo-server-external` and the `flux-webhook` are the only subdomains reachable from the public internet. In order to make additional applications public you must set set the correct ingress class name and ingress annotations like in the HelmRelease for `echo-server`.
-
-#### 🏠 Home DNS
-
-`k8s_gateway` will provide DNS resolution to external Kubernetes resources (i.e. points of entry to the cluster) from any device that uses your home DNS server. For this to work, your home DNS server must be configured to forward DNS queries for `${bootstrap_cloudflare.domain}` to `${bootstrap_cloudflare.gateway_vip}` instead of the upstream DNS server(s) it normally uses. This is a form of **split DNS** (aka split-horizon DNS / conditional forwarding).
-
-> [!TIP]
-> Below is how to configure a Pi-hole for split DNS. Other platforms should be similar.
-> 1. Apply this file on the Pihole server while substituting the variables
-> ```sh
-> # /etc/dnsmasq.d/99-k8s-gateway-forward.conf
-> server=/${bootstrap_cloudflare.domain}/${bootstrap_cloudflare.gateway_vip}
-> ```
-> 2. Restart dnsmasq on the server.
-> 3. Query an internal-only subdomain from your workstation (any `internal` class ingresses): `dig @${home-dns-server-ip} echo-server-internal.${bootstrap_cloudflare.domain}`. It should resolve to `${bootstrap_cloudflare.ingress_vip}`.
-
-If you're having trouble with DNS be sure to check out these two GitHub discussions: [Internal DNS](https://github.com/onedr0p/cluster-template/discussions/719) and [Pod DNS resolution broken](https://github.com/onedr0p/cluster-template/discussions/635).
-
-... Nothing working? That is expected, this is DNS after all!
-
-#### 📜 Certificates
-
-By default this template will deploy a wildcard certificate using the Let's Encrypt **staging environment**, which prevents you from getting rate-limited by the Let's Encrypt production servers if your cluster doesn't deploy properly (for example due to a misconfiguration). Once you are sure you will keep the cluster up for more than a few hours be sure to switch to the production servers as outlined in `config.yaml`.
-
-📍 _You will need a production certificate to reach internet-exposed applications through `cloudflared`._
-
-#### 🪝 Github Webhook
-
-By default Flux will periodically check your git repository for changes. In order to have Flux reconcile on `git push` you must configure Github to send `push` events to Flux.
-
-> [!NOTE]
-> This will only work after you have switched over certificates to the Let's Encrypt Production servers.
-
-1. Obtain the webhook path
-
-    📍 _Hook id and path should look like `/hook/12ebd1e363c641dc3c2e430ecf3cee2b3c7a5ac9e1234506f6f5f3ce1230e123`_
-
-    ```sh
-    kubectl -n flux-system get receiver github-receiver -o jsonpath='{.status.webhookPath}'
-    ```
-
-2. Piece together the full URL with the webhook path appended
-
-    ```text
-    https://flux-webhook.${bootstrap_cloudflare.domain}/hook/12ebd1e363c641dc3c2e430ecf3cee2b3c7a5ac9e1234506f6f5f3ce1230e123
-    ```
-
-3. Navigate to the settings of your repository on Github, under "Settings/Webhooks" press the "Add webhook" button. Fill in the webhook url and your `bootstrap_github_webhook_token` secret and save.
-
-## 💥 Nuke
-
-There might be a situation where you want to destroy your Kubernetes cluster. This will completely clean the OS of all traces of the Kubernetes distribution you chose and then reboot the nodes.
+Tools are pinned in `[mise.toml](./mise.toml)` and environment variables in `[.envrc](./.envrc)`. `mise install` and `direnv allow` set up a workstation.
 
 ```sh
-# k3s: Remove all traces of k3s from the nodes
-task ansible:run playbook=cluster-nuke
-# Talos: Reset your nodes back to maintenance mode and reboot
-task talos:soft-nuke
-# Talos: Comletely format your the Talos installation and reboot
-task talos:hard-nuke
+task                              # list every task
+flux get kustomizations -A        # what is reconciling, and what is not
+flux get helmreleases -A
+task flux:reconcile               # pull changes from git now, rather than waiting
+task kubernetes:kubeconform       # validate manifests the way CI does
+task kubernetes:resources         # gather cluster state for troubleshooting
+k9s                               # poke around
+stern -n default <app>            # tail logs
 ```
 
-## 🤖 Renovate
+> Recovery runbooks: placeholder. Filled in as each one is exercised.
 
-[Renovate](https://www.mend.io/renovate) is a tool that automates dependency management. It is designed to scan your repository around the clock and open PRs for out-of-date dependencies it finds. Common dependencies it can discover are Helm charts, container images, GitHub Actions, Ansible roles... even Flux itself! Merging a PR will cause Flux to apply the update to your cluster.
 
-To enable Renovate, click the 'Configure' button over at their [Github app page](https://github.com/apps/renovate) and select your repository. Renovate creates a "Dependency Dashboard" as an issue in your repository, giving an overview of the status of all updates. The dashboard has interactive checkboxes that let you do things like advance scheduling or reattempt update PRs you closed without merging.
 
-The base Renovate configuration in your repository can be viewed at [.github/renovate.json5](./.github/renovate.json5). By default it is scheduled to be active with PRs every weekend, but you can [change the schedule to anything you want](https://docs.renovatebot.com/presets-schedule), or remove it if you want Renovate to open PRs right away.
+## Bootstrapping
 
-## 🐛 Debugging
+> Placeholder. Filled in as the cluster is built.
 
-Below is a general guide on trying to debug an issue with an resource or application. For example, if a workload/resource is not showing up or a pod has started but in a `CrashLoopBackOff` or `Pending` state.
 
-1. Start by checking all Flux Kustomizations & Git Repository & OCI Repository and verify they are healthy.
 
-    ```sh
-    flux get sources oci -A
-    flux get sources git -A
-    flux get ks -A
-    ```
+## Repository layout
 
-2. Then check all the Flux Helm Releases and verify they are healthy.
+```
+kubernetes/main/       old cluster manifests: bootstrap/, flux/, apps/, templates/
+ansible/               node provisioning
+terraform/             Cloudflare R2 buckets and tunnel
+plans/                 design docs, written before the work
+.taskfiles/            task definitions
+scripts/               validation and helper scripts
+```
 
-    ```sh
-    flux get hr -A
-    ```
+## AI
 
-3. Then check the if the pod is present.
+I leverage coding agents heavily to help build and maintain this project since my time is very limited. I do try to review every line of code though.
 
-    ```sh
-    kubectl -n <namespace> get pods -o wide
-    ```
+[AGENTS.md](./AGENTS.md) covers AI best practices: the app layout, secrets handling, validation, and the failure modes this cluster has hit.
 
-4. Then check the logs of the pod if its there.
+## Credits
 
-    ```sh
-    kubectl -n <namespace> logs <pod-name> -f
-    # or
-    stern -n <namespace> <fuzzy-name>
-    ```
+I am so incredibly thankful to many contributors of the home automation / self-hosting / OSS community. You have my eternal gratitude.
 
-5. If a resource exists try to describe it to see what problems it might have.
-
-    ```sh
-    kubectl -n <namespace> describe <resource> <name>
-    ```
-
-6. Check the namespace events
-
-    ```sh
-    kubectl -n <namespace> get events --sort-by='.metadata.creationTimestamp'
-    ```
-
-Resolving problems that you have could take some tweaking of your YAML manifests in order to get things working, other times it could be a external factor like permissions on NFS. If you are unable to figure out your problem see the help section below.
-
-## 👉 Help
-
-- Make a post in this repository's Github [Discussions](https://github.com/onedr0p/cluster-template/discussions).
-- Start a thread in the `#support` or `#cluster-template` channels in the [Home Operations](https://discord.gg/home-operations) Discord server.
-
-## ❔ What's next
-
-The cluster is your oyster (or something like that). Below are some optional considerations you might want to review.
-
-#### Ship it
-
-To browse or get ideas on applications people are running, community member [@whazor](https://github.com/whazor) created [Kubesearch](https://kubesearch.dev) as a creative way to search Flux HelmReleases across Github and Gitlab.
-
-#### Storage
-
-The included CSI (openebs in local-hostpath mode) is a great start for storage but soon you might find you need more features like replicated block storage, or to connect to a NFS/SMB/iSCSI server. If you need any of those features be sure to check out the projects like [rook-ceph](https://github.com/rook/rook), [longhorn](https://github.com/longhorn/longhorn), [openebs](https://github.com/openebs/openebs), [democratic-csi](https://github.com/democratic-csi/democratic-csi), [csi-driver-nfs](https://github.com/kubernetes-csi/csi-driver-nfs),
-and [synology-csi](https://github.com/SynologyOpenSource/synology-csi).
-
-## 🙌 Related Projects
-
-If this repo is too hot to handle or too cold to hold check out these following projects.
-
-- [khuedoan/homelab](https://github.com/khuedoan/homelab) - _Modern self-hosting framework, fully automated from empty disk to operating services with a single command._
-- [danmanners/aws-argo-cluster-template](https://github.com/danmanners/aws-argo-cluster-template) - _A community opinionated template for deploying Kubernetes clusters on-prem and in AWS using Pulumi, SOPS, Sealed Secrets, GitHub Actions, Renovate, Cilium and more!_
-- [ricsanfre/pi-cluster](https://github.com/ricsanfre/pi-cluster) - _Pi Kubernetes Cluster. Homelab kubernetes cluster automated with Ansible and ArgoCD_
-- [techno-tim/k3s-ansible](https://github.com/techno-tim/k3s-ansible) - _The easiest way to bootstrap a self-hosted High Availability Kubernetes cluster. A fully automated HA k3s etcd install with kube-vip, MetalLB, and more_
-
-## ⭐ Stargazers
-
-<div align="center">
-
-[![Star History Chart](https://api.star-history.com/svg?repos=onedr0p/cluster-template&type=Date)](https://star-history.com/#onedr0p/cluster-template&Date)
-
-</div>
-
-## 🤝 Thanks
-
-Big shout out to all the contributors, sponsors and everyone else who has helped on this project.
+This project started from [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template) and has since diverged. The manifests here are edited directly rather than generated.


### PR DESCRIPTION
Adds an agent-facing guide and replaces the stale upstream README.

## AGENTS.md

New file covering how to change this repo, with `CLAUDE.md` symlinked to it so both toolchains read the same guidance.

- Ground rules: read-only against the live cluster, never `kubectl apply` over Flux, never touch plaintext secrets, read the plan first.
- The two cluster trees, and which one new work belongs in.
- App directory layout and the steps to add one, drawn from how `mealie` is actually structured.
- Community references, including `home-operations/k8s-schemas` and `home-operations/containers`.
- Patterns inferred from the existing manifests, framed as guidelines to follow where they fit: manifest conventions, config in Helm values with credentials in secrets, one Flux Kustomization per lifecycle, non-root containers, and CPU requests without CPU limits.
- Secrets handling for both SOPS and 1Password, validation, code style, and Graphite for the PR lifecycle, including a rule against force pushing.
- Gotchas that have already bitten this cluster: VolSync on empty PVCs, stopping a stuck CNPG pod, Longhorn replica placement.
- A closing section asking agents to propose doc updates alongside the work that invalidates them.

## README.md

The old README was the unmodified `onedr0p/cluster-template` one, documenting a makejinja templating workflow this repo abandoned. Following it would have overwritten hand-edited manifests.

The rewrite describes this cluster instead. It is written Talos-forward, with migration detail confined to a warning banner and a status section, and everything else pointing at `plans/20260816-talos-migration.md` as the authority. Hardware, app inventory, and bootstrapping are placeholders until the resources they describe exist.

## Notes

No manifests change, so `flux-diff` should be empty.